### PR TITLE
Updated to use version 1.0.5 of aws-cloudwatch-exts-commons.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ To set an encrypted awsAccessKey and awsSecretKey in config.yaml, follow the ste
    	
 3. Set the decryptionKey field in config.yaml with the encryption key used, as well as the resulting encrypted awsAccessKey and awsSecretKey in their respective fields.
 
+###AWS Instance Profiles
+When running on an EC2 instance, you can use the IAM instance profile on the instance instead of storing credentials in
+your configuration file.
+
+To use instance profiles instead of keys in the `config.yaml`, follow all the installation steps but leave the
+`awsAccessKey` and `awsSecretKey` fields blank in the `config.yaml` or omit them. The extension will then get temporary
+credentials from using the instance profile each time metrics are sent to your AppDynamcis controller.
+
 ##Metrics
 Typical metric path: **Application Infrastructure Performance|\<Tier\>|Custom Metrics|Amazon Custom Namespace|\<Namespace\>|\<Account Name\>|\<Region\>** followed by the metrics defined by your custom namespace.
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.appdynamics.extensions</groupId>
 	<artifactId>aws-customnamespace-monitoring-extension</artifactId>
-	<version>1.0.1</version>
+	<version>1.1.0</version>
 	<name>AWS Custom Namespace Monitoring Extension</name>
 	
 	<properties>
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>com.appdynamics.extensions</groupId>
 			<artifactId>aws-cloudwatch-exts-commons</artifactId>
-			<version>1.0.1</version>
+			<version>1.0.5</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/com/appdynamics/extensions/aws/customnamespace/CustomNamespaceMetricsProcessor.java
+++ b/src/main/java/com/appdynamics/extensions/aws/customnamespace/CustomNamespaceMetricsProcessor.java
@@ -41,7 +41,7 @@ public class CustomNamespaceMetricsProcessor implements MetricsProcessor {
 		this.namespace = namespace;
 	}
 
-	public List<Metric> getMetrics(AmazonCloudWatch awsCloudWatch) {
+	public List<Metric> getMetrics(AmazonCloudWatch awsCloudWatch, String accountName) {
 		return MetricsProcessorHelper.getFilteredMetrics(awsCloudWatch, 
 				namespace, 
 				excludeMetricsPattern);


### PR DESCRIPTION
This allows the extension to use EC2 instance profiles instead of IAM user access keys.