### PR TITLE
Updated to Java 17 and Update appd-ext-commons to 2.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.5 - Aug 07, 2025
+1. Updated ext to be compatible with Java 17
+2. Updated appd-ext-commons to 2.2.16 having apache commons-lang3 3.18.0
+
 ## 2.0.3 - May 20, 2022
 1. Fixed issue for getStatisticType
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.appdynamics.extensions</groupId>
 	<artifactId>aws-customnamespace-monitoring-extension</artifactId>
-	<version>2.0.4</version>
+	<version>2.0.5</version>
 	<name>AWS Custom Namespace Monitoring Extension</name>
 	
 	<properties>
@@ -25,14 +25,14 @@
 		<dependency>
 			<groupId>com.appdynamics</groupId>
 			<artifactId>machineagent</artifactId>
-			<version>25.1</version>
-			<systemPath>${project.basedir}/../25.1/machineagent.jar</systemPath>
+			<version>25.7</version>
+			<systemPath>${project.basedir}/../25.7/machineagent.jar</systemPath>
 			<scope>system</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.appdynamics</groupId>
 			<artifactId>appd-exts-commons</artifactId>
-			<version>2.2.13</version>
+			<version>2.2.16</version>
 		</dependency>
 		<dependency>
 			<groupId>com.appdynamics.extensions</groupId>
@@ -79,8 +79,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.3.2</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Updated to be compatible with Java 17 and Updated appd-ext-commons to 2.2.16 having apache commons-lang3 3.18.0